### PR TITLE
CF Node log considerations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ node_modules/*
 .vscode/*
 etc/bigquery-private-key.json
 etc/databricks-token.json
-log/log.txt
+*.log
 *.idea
 .env

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ require('make-promises-safe'); // installs an 'unhandledRejection' handler
 const path = require('path');
 const _ = require('lodash');
 require('dotenv').config();
-let logFilePath = process.env.FASTIFY_LOG_PATH || path.join(__dirname, '..', 'log', 'fastify-logs.txt');
+let logFilePath = process.env.FASTIFY_LOG_PATH || path.join(__dirname, '..', 'log', 'fastify.log');
 
 function buildFastify() {
     const fastify = require('fastify')({

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ const { ClientRequestInterceptor } = require('@mswjs/interceptors/lib/intercepto
 require('make-promises-safe'); // installs an 'unhandledRejection' handler
 const path = require('path');
 const _ = require('lodash');
-let logFilePath = process.env.FASTIFY_LOG_PATH || path.join(__dirname, '..', 'log', 'fastify-logs.txt');
 require('dotenv').config();
+let logFilePath = process.env.FASTIFY_LOG_PATH || path.join(__dirname, '..', 'log', 'fastify-logs.txt');
 
 function buildFastify() {
     const fastify = require('fastify')({

--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,14 @@ const { ClientRequestInterceptor } = require('@mswjs/interceptors/lib/intercepto
 require('make-promises-safe'); // installs an 'unhandledRejection' handler
 const path = require('path');
 const _ = require('lodash');
-let logFilePath = path.join(__dirname, '..', 'log', 'log.txt');
+let logFilePath = process.env.FASTIFY_LOG_PATH || path.join(__dirname, '..', 'log', 'fastify-logs.txt');
 require('dotenv').config();
 
 function buildFastify() {
     const fastify = require('fastify')({
         bodyLimit: 999999999,
         logger: {
-            level: process.env.LOG_LEVEL || 'info',
+            level: process.env.FASTIFY_LOG_LEVEL || 'info',
             file: logFilePath
         }
     });
@@ -30,7 +30,7 @@ function buildFastify() {
         fastify.log.info(`server listening on ${address}`);
     });
 
-    console.log('log level: ', process.env.LOG_LEVEL);
+    console.log('fastify log level: ', process.env.FASTIFY_LOG_LEVEL);
     if (process.env.LOG_LEVEL === 'debug') {
         const interceptor = new ClientRequestInterceptor()
         interceptor.apply();

--- a/src/routes.js
+++ b/src/routes.js
@@ -20,7 +20,7 @@ cf.log.methodFactory = function (methodName, logLevel, loggerName) {
 
     return (...args) => {
         // Define the log file path
-        const logFilePath = process.env.CF_LOG_PATH || path.join(__dirname, '..', 'log', 'cft-log.log');
+        const logFilePath = process.env.CF_LOG_PATH || path.join(__dirname, '..', 'log', 'chartfactor.log');
 
         if (!fs.existsSync(logFilePath)) {
             fs.mkdirSync(path.dirname(logFilePath), { recursive: true });

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,6 +10,35 @@ const providers = JSON.parse(rawdata);
 
 // Supported providers
 require('../cft/cftoolkit')
+
+const cf = global.cf;
+
+const originalFactory = cf.log.methodFactory;
+
+cf.log.methodFactory = function (methodName, logLevel, loggerName) {
+    const rawMethod = originalFactory(methodName, logLevel, loggerName);
+
+    return (...args) => {
+        // Define the log file path
+        const logFilePath = process.env.CF_LOG_PATH || path.join(__dirname, '..', 'log', 'cft-log.log');
+
+        if (!fs.existsSync(logFilePath)) {
+            fs.mkdirSync(path.dirname(logFilePath), { recursive: true });
+            fs.writeFileSync(logFilePath, '');
+        }
+
+        // Append the log entry to the file
+        const logMessage = `${new Date().toISOString()} ${methodName.toUpperCase()}: ${args.join(' ')}\n`;
+        fs.appendFileSync(logFilePath, logMessage);
+
+        // Write to the original `loglevel` output
+        rawMethod(...args);
+    };
+};
+
+// Apply the new method factory
+cf.log.setLevel(cf.log.getLevel());
+
 const ElasticProvider = require('../cft/cft-elasticsearch-provider');
 const RedshiftProvider = require('../cft/cft-redshift-provider');
 const BigQueryProvider = require('../cft/cft-google-bigquery-provider');


### PR DESCRIPTION
CF Node log considerations
Be able to configure the ChartFactor loggers to write logs on a file instead of on the console. Allow to override log path using the .env file
CFNode: .env configuration for the fastify logger should be FASTIFY_LOG_LEVEL
CFNode: console output should be “Fastify log level” instead of just “log level”
